### PR TITLE
Fix iOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The group name must come directly after `group:` with a `/` after it
 - [x] MacOS
 
 - [x] Android
-- [x] iOS (Untested)
+- [x] iOS
 
 
 ## Installation

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import PathLinkerPlugin from "./main";
-import { App, PluginSettingTab, Setting, TextComponent, Platform } from "obsidian";
+import { App, PluginSettingTab, Setting, TextComponent, Platform, Notice } from "obsidian";
 
 
 interface Device {
@@ -26,6 +26,10 @@ async function chooseFolder(): Promise<string|null> {
 	let selectedPath = null;
 
 	if (Platform.isMobile) {
+		if (Platform.isIosApp) {
+			// iOS doesn't support folder picker
+			return null;
+		}
 		try {
 			const result = await (window as any).Capacitor.Plugins.Filesystem.choose();
 			return result.path;
@@ -33,7 +37,7 @@ async function chooseFolder(): Promise<string|null> {
 			if (e.message !== 'canceled') console.error(e);
 			return null;
 		}
-	} 
+	}
 
 	// Desktop
 	const electron = require('electron');
@@ -161,7 +165,14 @@ export class PathLinkerPluginSettingTab extends PluginSettingTab {
 					.setIcon('folder')
 					.setTooltip('Select folder')
 					.onClick(async () => {
-			
+						if (Platform.isIosApp) {
+							new Notice(
+								'Folder picker is not available on iOS. Please enter the base path, relative to your vault.',
+								8000
+							);
+							return;
+						}
+
 						const selectedFolder = await chooseFolder();
 
 						if (!selectedFolder) return;


### PR DESCRIPTION
These changes were necessary for me to link to a folder outside the vault on iOS.

For example, this allows: `external:../media/test.jpg`, pointing to a file in a "media" directory that's a sibling to the current vault in iOS.

Since iOS apps are sandboxed, paths (including "Device base path" for a group) need to be relative, and in this case, relative to the current vault.

Also, from what I can tell, the iOS version of Obsidian doesn't seem to support the folder picker, so I've included a message about needing to manually enter the relative path when setting the device base path for an iOS device in a group.