### PR TITLE
Fix Dataview index loop and iOS file access

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -328,10 +328,15 @@ export default class PathLinkerPlugin extends Plugin {
         this.originalGetFirstLinkpathDest = this.app.metadataCache.getFirstLinkpathDest;
         this.app.metadataCache.getFirstLinkpathDest = (linkpath: string, sourcePath: string): TFile | null => {
             if (linkpath.startsWith(externalPrefix) || linkpath.startsWith(externalGroupPrefix)) {
-                // Return a custom file object for external links
-                // This creates a TFile object to a file that doesn't exist so that obisidan will try to read it
-                // This read will later be intercepted so that the correct file is read
-                return this.createFakeFile(linkpath);
+                // Never feed a fake TFile into the global metadata cache.
+                // The fake file (parent: null, path prefixed with _externalPrefix,
+                // empty stat) never resolves to a real vault file, so index-scanning
+                // consumers such as Dataview never reach a fixed point and stay stuck
+                // in "still indexing". Display and opening of these links is handled
+                // entirely by the markdown post processor / editor widget in nonembed.ts,
+                // which does not need this TFile. Returning null lets indexers ignore
+                // the link cleanly.
+                return null;
             }
 
             // Call the original method for internal links
@@ -343,7 +348,16 @@ export default class PathLinkerPlugin extends Plugin {
         // Mostly for PDF++
         this.originalGetFullPath = (this.app.vault.adapter as any).getFullPath;
 
-        if (this.originalGetFullPath !== undefined)
+        // Only override getFullPath on desktop. This override replaces
+        // Obsidian's getFullPath for EVERY file access, not just external links.
+        // On iOS/mobile the vault adapter's base path handling differs, so routing
+        // every path through useVaultAsWorkingDirectory() produces an invalid path
+        // and makes ALL notes fail to open ("could not open ..."). External/group
+        // links do not rely on this override: they are opened via openInDefaultApp()
+        // -> adapter.fs.open(), which resolves the working directory itself. The
+        // override exists mostly for PDF++ on desktop, so guarding it with
+        // !Platform.isMobile keeps that intact while fixing mobile.
+        if (this.originalGetFullPath !== undefined && !Platform.isMobile)
         (this.app.vault.adapter as any).getFullPath = (path: string) => {
             let fullPath = this.originalGetFullPath.call(this.app.vault.adapter, path);
 
@@ -355,8 +369,6 @@ export default class PathLinkerPlugin extends Plugin {
 
             fullPath = this.useVaultAsWorkingDirectory(fullPath);
 
-            console.log(path + "\n" + fullPath);
-
             return fullPath;
         }
     }
@@ -367,7 +379,7 @@ export default class PathLinkerPlugin extends Plugin {
         // Restore the original methods
         this.app.metadataCache.getFirstLinkpathDest = this.originalGetFirstLinkpathDest;
 
-        if (this.originalGetFullPath !== undefined)
+        if (this.originalGetFullPath !== undefined && !Platform.isMobile)
         (this.app.vault.adapter as any).getFullPath = this.originalGetFullPath;
     }
 


### PR DESCRIPTION
Fix: stop poisoning the metadata cache (Dataview stuck "indexing") and fix all-files-fail-to-open on iOS

Fixes #7.
Likely also addresses #14 (No iOS support) — see note below; would appreciate
confirmation from the reporter, since I can only verify against my own iPadOS setup.

## Summary

This PR fixes two related problems caused by how the plugin injects external/group
links into Obsidian's core APIs:

1. **Desktop + mobile:** `getFirstLinkpathDest` returned a synthetic `TFile` for every
  `external:` / `group:` link. Because that fake file never corresponds to a real vault
  file (`parent: null`, `path` carrying the internal `_externalPrefix` marker, empty
  `stat`), any consumer that scans the metadata cache cannot reconcile it. In particular
  **Dataview never reaches a stable index** and stays in a permanent "still indexing"
  state (visible, for example, through Excalibrain's Dataview status readout). This
  degrades every plugin that depends on the Dataview index.
  
2. **iOS/iPadOS:** with the plugin enabled, **every file fails to open** ("`<file>` could
  not be opened"), including ordinary internal notes. Disabling the plugin restores
  access. The cause is the global `getFullPath` override: it replaces Obsidian's
  `getFullPath` for *all* file access and routes every path through
  `useVaultAsWorkingDirectory()`, whose base-path assumptions do not hold on the mobile
  vault adapter, producing invalid paths.
  

## Changes

- **`getFirstLinkpathDest` returns `null` for external/group links** instead of a fake
  `TFile`. Rendering and opening of these links is handled entirely by the markdown post
  processor / editor widget in `nonembed.ts`, which does not need a `TFile`. Returning
  `null` lets index-scanning consumers ignore the link cleanly, so the Dataview index
  converges. `createFakeFile()` is left in place (now unused) to keep the diff minimal.
  
- **`getFullPath` is only overridden on desktop** (`!Platform.isMobile`), in both
  `onload` and `onunload`. The override exists mostly for PDF++ on desktop, which is
  unaffected. External/group links do not depend on it: they are opened via
  `openInDefaultApp()` → `adapter.fs.open()`, which resolves the working directory
  itself. This keeps desktop behaviour identical while fixing mobile file access.
  
- **Removed a `console.log`** in the `getFullPath` override that fired on every file
  access and added noise/overhead during indexing.
  

## Why this is safe

- Desktop behaviour is unchanged: the `getFullPath` override still runs there, and
  `nonembed.ts` continues to render and open links.
- On mobile, external/group links continue to open through the existing
  `openInDefaultApp()` path, which never relied on the `getFullPath` override.
- The change is minimal and localized to `onload`/`onunload`; no public API or settings
  change.

## Testing

- **Windows (desktop):** `[[group:...]]` links resolve and open in the default app as
  before; Dataview index now completes instead of looping.
- **iPadOS:** with the plugin enabled, ordinary notes open again, and `[[group:...]]`
  links still open their external targets.

## Notes / open questions for the maintainer

- **Re #14 (No iOS support):** the second fix restores normal file access on iPadOS with
  the plugin enabled, and group links continue to open. If #14 refers to this
  all-files-fail-to-open symptom, this PR should resolve it; if it refers to a different
  iOS problem (e.g. group path resolution or a startup crash), that may need a separate
  look. I can only confirm against my own iPadOS device, so confirmation from the reporter
  would help before closing #14.
- I scoped the `getFullPath` override off on *all* mobile platforms via
  `Platform.isMobile`. If a mobile use case genuinely needs it (e.g. a specific embed
  scenario), a narrower guard could be considered, but for link-only usage this is not
  required.
- `createFakeFile()` becomes dead code with this change. It can be removed in a follow-up
  if you prefer; I left it to keep the review surface small and make reverting trivial.